### PR TITLE
Fix group name quoting

### DIFF
--- a/ads_screenshot.py
+++ b/ads_screenshot.py
@@ -37,7 +37,9 @@ def screenshot_group_stats(group_name, output_file, ads_url):
         # --- После капчи (или если её не было) продолжаем как обычно:
         try:
             # Используем неполное совпадение текста, чтобы учесть различия в названии
-            group_row = page.locator(f"text={group_name}").first
+            # Use exact text matching with quoting to correctly handle
+            # group names that contain spaces or special characters
+            group_row = page.locator(f'text="{group_name}"').first
             if group_row.count() > 0:
                 stat_btn = (
                     group_row


### PR DESCRIPTION
## Summary
- quote group names in screenshot_group_stats to handle spaces/special chars

## Testing
- `python -m py_compile ads_screenshot.py`
- `python - <<'PY'
from ads_screenshot import screenshot_group_stats
try:
    screenshot_group_stats('Example Group Name', 'test.png', 'https://example.com')
    print('script ran')
except Exception as e:
    print('error:', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6845d96871748324bf8973343658931b