### PR TITLE
Remove stray debug print

### DIFF
--- a/vk_auth.py
+++ b/vk_auth.py
@@ -1,7 +1,6 @@
 from playwright.sync_api import sync_playwright
 
 with sync_playwright() as p:
-    print("dadsad:")
     browser = p.chromium.launch(headless=False)
     context = browser.new_context()
     page = context.new_page()


### PR DESCRIPTION
## Summary
- clean up vk_auth debug output

## Testing
- `python vk_auth.py` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_e_6845d969b72c83248121703a4e1619ab