### PR TITLE
Add persistent Chrome context helper for VK Ads automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This project creates screenshots of VK posts and statistics of the related adver
 ## Requirements
 
 - Python 3.8+
-- Google Chrome/Chromium browsers used by [Playwright](https://playwright.dev/)
+- Google Chrome installed (Playwright launches the desktop browser via the `chrome` channel).
+  The scripts reuse the local profile stored in `.playwright-profile` to keep the browser looking human and reduce captcha prompts.
 
 Install Python dependencies:
 

--- a/vk_ads_auth.py
+++ b/vk_ads_auth.py
@@ -1,26 +1,31 @@
 from playwright.sync_api import sync_playwright
 
+from vk_ads_context import create_vk_ads_context
+
+
 def auth_vk_ads():
-    """Авторизация специально для VK Ads и сохранение сессии"""
+    """Авторизация специально для VK Ads и сохранение сессии."""
+
     with sync_playwright() as p:
-        browser = p.chromium.launch(headless=False)
-        context = browser.new_context()
-        page = context.new_page()
-        
-        print("Открываю VK Ads для авторизации...")
-        page.goto("https://ads.vk.com/hq/dashboard/ad_groups")
-        
-        print("Войди в свой VK-аккаунт через VK Ads.")
-        print("Пройди все проверки, двухфакторку если нужно.")
-        print("Дождись полной загрузки страницы с рекламными группами.")
-        
-        input("Когда страница VK Ads полностью загрузится и ты авторизован, нажми Enter...")
-        
-        # Сохраняем сессию специально для VK Ads
-        context.storage_state(path="vk_ads_storage.json")
-        print("✅ Сессия VK Ads сохранена в vk_ads_storage.json")
-        
-        browser.close()
+        context = create_vk_ads_context(p)
+        try:
+            page = context.new_page()
+
+            print("Открываю VK Ads для авторизации...")
+            page.goto("https://ads.vk.com/hq/dashboard/ad_groups")
+
+            print("Войди в свой VK-аккаунт через VK Ads.")
+            print("Пройди все проверки, двухфакторку если нужно.")
+            print("Дождись полной загрузки страницы с рекламными группами.")
+
+            input("Когда страница VK Ads полностью загрузится и ты авторизован, нажми Enter...")
+
+            # Сохраняем сессию специально для VK Ads
+            context.storage_state(path="vk_storage.json")
+            print("✅ Сессия VK Ads сохранена в vk_storage.json")
+        finally:
+            context.close()
+
 
 if __name__ == "__main__":
     auth_vk_ads()

--- a/vk_ads_context.py
+++ b/vk_ads_context.py
@@ -1,0 +1,46 @@
+"""Utilities for launching a realistic Playwright context for VK Ads."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Union
+
+from playwright.sync_api import BrowserContext, Playwright
+
+# User agent string of a recent stable Chrome build on Windows.
+_CHROME_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0.0.0 Safari/537.36"
+)
+
+StorageState = Union[str, Dict[str, Any]]
+
+
+def create_vk_ads_context(
+    playwright: Playwright,
+    *,
+    storage_state: Optional[StorageState] = None,
+    viewport: Optional[Dict[str, int]] = None,
+    **overrides: Any,
+) -> BrowserContext:
+    """Create a persistent Playwright context tuned for VK Ads automation."""
+
+    launch_options: Dict[str, Any] = {
+        "user_data_dir": ".playwright-profile",
+        "channel": "chrome",
+        "headless": False,
+        "ignore_default_args": ["--enable-automation"],
+        "args": ["--disable-blink-features=AutomationControlled"],
+        "locale": "ru-RU",
+        "timezone_id": "Europe/Moscow",
+        "user_agent": _CHROME_USER_AGENT,
+    }
+
+    if storage_state is not None:
+        launch_options["storage_state"] = storage_state
+    if viewport is not None:
+        launch_options["viewport"] = viewport
+
+    launch_options.update(overrides)
+
+    return playwright.chromium.launch_persistent_context(**launch_options)


### PR DESCRIPTION
## Summary
- add a reusable helper that opens a persistent Chrome context tuned for VK Ads
- switch vk_ads_auth and ads_screenshot to the shared helper and reuse the saved storage state
- document Chrome requirement and the reusable `.playwright-profile`

## Testing
- python -m compileall vk_ads_context.py vk_ads_auth.py ads_screenshot.py

------
https://chatgpt.com/codex/tasks/task_e_68cd224141a883249521f338dfdcdf50